### PR TITLE
Fix dynAdd to allow countries with whitespaces in their names

### DIFF
--- a/mist.lua
+++ b/mist.lua
@@ -591,7 +591,7 @@ do
 	-- validate data
 	for countryId, countryName in pairs(country.name) do
 		if type(cntry) == 'string' then
-            cntry = cntry:gsub("%s+", "_")
+			cntry = cntry:gsub("%s+", "_")
 			if tostring(countryName) == string.upper(cntry) then
 				newCountry = countryName
 			end

--- a/mist.lua
+++ b/mist.lua
@@ -591,6 +591,7 @@ do
 	-- validate data
 	for countryId, countryName in pairs(country.name) do
 		if type(cntry) == 'string' then
+            cntry = cntry:gsub("%s+", "_")
 			if tostring(countryName) == string.upper(cntry) then
 				newCountry = countryName
 			end


### PR DESCRIPTION
This allows groups to be spawned if they were created off of template groups/units in the ME. The ME sets the country name of countries with whitespaces (e.g. "North Korea") whereas the enum string contains a underscore instead of the whitespace (e.g. "NORTH_KOREA"). This function would return false because it won't find the country name in the enum.

This fixes the issue by substituting whitespaces with a underscore using gsub().
