### PR TITLE
isTerrainValid validation for terrain types table fails with multiple entries

### DIFF
--- a/mist.lua
+++ b/mist.lua
@@ -6678,7 +6678,7 @@ do -- group tasks scope
 		elseif type(terrainTypes) == 'table' then -- if its a table it does this check
 			for typeId, typeData in pairs(terrainTypes) do
 				for constId, constData in pairs(land.SurfaceType) do
-					if string.lower(constId) == string.lower(typeData) or string.lower(constData) == string.lower(typeId) then
+					if string.lower(constId) == string.lower(typeData) or string.lower(constData) == string.lower(typeData) then
 						table.insert(typeConverted, constId)
 					end
 				end


### PR DESCRIPTION
Providing a table of terrain types compares the `terrainTypes` table index against DCS' `SurfaceType` enum values, always including the `LAND` surface type if more than one terrainType was provided.

Example:
```lua
-- _terrainPoint is a random point (vec2) on land, e.g. in the Caucasus mountains
mist.isTerrainValid(_terrainPoint, 'LAND') -- returns true
mist.isTerrainValid(_terrainPoint, 'WATER') -- returns false
mist.isTerrainValid(_terrainPoint, 'SHALLOW_WATER') -- returns false
mist.isTerrainValid(_terrainPoint, {'WATER', 'SHALLOW_WATER'}) -- return true, comparison with index of terrainTypes table matches 1, including SurfaceType.WATER in the types checked against
```

I assume the second check when validating the provided `terrainTypes` table is intended to allow the enum's values to be provided as well, e.g. as `mist.isTerrainTypes(_terrainPoint, {'WATER', 3})`, however the comparison incorrectly checks the table's index against the enum's values.
This PR fixes the comparison, checking the assummed intended `terrainTypes` value against the `SurfaceType` enum value.

Happy to provide a short demo mission/script to showcase the issue if required 😄 