### PR TITLE
Adding route name fetch to getGroupRoute()

### DIFF
--- a/mist.lua
+++ b/mist.lua
@@ -6395,6 +6395,11 @@ do -- group tasks scope
 
 												for point_num, point in pairs(group_data.route.points) do
 													local routeData = {}
+													if env.mission.version > 7 then
+														routeData.name = env.getValueDictByKey(point.name)
+													else
+														routeData.name = point.name
+													end
 													if not point.point then
 														routeData.x = point.x
 														routeData.y = point.y

--- a/mist_4_4_83.lua
+++ b/mist_4_4_83.lua
@@ -6395,6 +6395,11 @@ do -- group tasks scope
 
 												for point_num, point in pairs(group_data.route.points) do
 													local routeData = {}
+													if env.mission.version > 7 then
+														routeData.name = env.getValueDictByKey(point.name)
+													else
+														routeData.name = point.name
+													end
 													if not point.point then
 														routeData.x = point.x
 														routeData.y = point.y


### PR DESCRIPTION
Adding in fetching of route names so that more specific processing can be accomplished around named WPs. This allows mission designers the ability to produce richer mission content via different methods of processing WPs on a named basis.