### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.lua]
+indent_style = tab
+tab_width = 2


### PR DESCRIPTION
GitHub honours this file and then renders indentation as intended. Makes for a much nicer experience reading the code in GitHub's web interface.

Before:
![image](https://user-images.githubusercontent.com/119659/92992902-5664c700-f52d-11ea-9c65-a64f2ac33168.png)

After:
![image](https://user-images.githubusercontent.com/119659/92992929-7f855780-f52d-11ea-94b3-b7ac6648bd5c.png)
