### PR TITLE
4.5 Release Hotfix 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Forum Thread: http://forums.eagle.ru/showthread.php?t=98616
 
 Documentation
 ====
-The MIST Wiki page can be fore at this address: http://wiki.hoggit.us/view/Mission_Scripting_Tools_Documentation
+The MIST Wiki page can be found at this address: http://wiki.hoggit.us/view/Mission_Scripting_Tools_Documentation
 
-The attached pdf "mist gude.pdf" is attached in the download. 
+The attached pdf "mist gude.pdf" is attached in the download however is no longer being updated. 
 
 Description
 ====


### PR DESCRIPTION
FIXED: bug in mist message output where display time failed to be updated.
FIXED: mist.marker.remove to support name values
Modified; mist.marker.add to automatically flip a polygon if the points are anti-clockwise. This is a workaround to a DCS bug.
FIXED: drawing DB entries for lines to support if the line is closed or not. If it is then a point will be inserted to connect the last vertex to the first.
CORRECTED: Included DB example files within release rar download.