### PR TITLE
Typo in mist.lua

### DIFF
--- a/mist.lua
+++ b/mist.lua
@@ -7396,7 +7396,7 @@ do
         else
             for mEntry, mData in pairs(mist.DBs.markList) do
                 if id == mData.name or id == mData.id then
-                    return mData.id
+                    return mData.markId
                 end
             end
         end


### PR DESCRIPTION
getMarkerId couldn't work, because it return .id, with isn't in the table.