### PR TITLE
Fix a counter error in updateDBTables()

### DIFF
--- a/mist.lua
+++ b/mist.lua
@@ -35,7 +35,7 @@ mist = {}
 -- don't change these
 mist.majorVersion = 4
 mist.minorVersion = 5
-mist.build = 126
+mist.build = 127
 
 -- forward declaration of log shorthand
 local log
@@ -1421,9 +1421,9 @@ do -- the main scope
 				else
 					writeGroups[x] = nil
 				end
-			end
-			if x%savesPerRun == 0 then
-				coroutine.yield()
+				if x%savesPerRun == 0 then
+					coroutine.yield()
+				end
 			end
 			if timer.getTime() > lastUpdateTime then
 				lastUpdateTime = timer.getTime()

--- a/mist_4_5_127.lua
+++ b/mist_4_5_127.lua
@@ -35,7 +35,7 @@ mist = {}
 -- don't change these
 mist.majorVersion = 4
 mist.minorVersion = 5
-mist.build = 125
+mist.build = 127
 
 -- forward declaration of log shorthand
 local log
@@ -1421,9 +1421,9 @@ do -- the main scope
 				else
 					writeGroups[x] = nil
 				end
-			end
-			if x%savesPerRun == 0 then
-				coroutine.yield()
+				if x%savesPerRun == 0 then
+					coroutine.yield()
+				end
 			end
 			if timer.getTime() > lastUpdateTime then
 				lastUpdateTime = timer.getTime()


### PR DESCRIPTION
Fix counter variable `x` out of scope error in function `updateDBTables`.

This issue was introduced since version 4.5.116. See [this commit](https://github.com/mrSkortch/MissionScriptingTools/commit/be5023e2fd76cbda5d1354cf8ff1a0828cc4522d) for detail.