### PR TITLE
lcg rng alternative for mist.random(), added mist.randomseed()

### DIFF
--- a/mist_4_5_126.lua
+++ b/mist_4_5_126.lua
@@ -4790,7 +4790,22 @@ do -- group functions scope
 		return newGroup
 	end
 
+	function mist.randomseed(seed)
+		mist.lcg_seed = seed or math.random(1, 2^32 - 1)
+		mist.lcg_a = 1664525
+		mist.lcg_c = 1013904223
+		mist.lcg_m = 2^32
+	end
+	
+	function mist.lcg_random()
+		mist.lcg_seed = (mist.lcg_a * mist.lcg_seed + mist.lcg_c) % mist.lcg_m
+		return mist.lcg_seed / mist.lcg_m
+	end
+	
 	function mist.random(firstNum, secondNum) -- no support for decimals
+		if mist.lcg_seed == nil then
+			mist.randomseed()
+		end
 		local lowNum, highNum
 		if not secondNum then
 			highNum = firstNum
@@ -4799,21 +4814,7 @@ do -- group functions scope
 			lowNum = firstNum
 			highNum = secondNum
 		end
-		local total = 1
-		if math.abs(highNum - lowNum + 1) < 50 then -- if total values is less than 50
-			total = math.modf(50/math.abs(highNum - lowNum + 1)) -- make x copies required to be above 50
-		end
-		local choices = {}
-		for i = 1, total do -- iterate required number of times
-			for x = lowNum, highNum do -- iterate between the range
-				choices[#choices +1] = x -- add each entry to a table
-			end
-		end
-		local rtnVal = math.random(#choices) -- will now do a math.random of at least 50 choices
-		for i = 1, 10 do
-			rtnVal = math.random(#choices) -- iterate a few times for giggles
-		end
-		return choices[rtnVal]
+		return lowNum + math.floor(mist.lcg_random() * (highNum - lowNum + 1))
 	end
     
     function mist.stringCondense(s)


### PR DESCRIPTION
based on https://en.wikipedia.org/wiki/Linear_congruential_generator

- fixes problem with big numbers, e.g. mist.random(10000000)
- better number distribution
- adds mist.randomseed() for seed control